### PR TITLE
feat(adr): provide adr-tools in Devbox shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Devbox
+.devbox

--- a/engineering-base/adr-setup.sh
+++ b/engineering-base/adr-setup.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Ensure /usr/local/bin/adr directory exists
+if [ ! -d "/usr/local/bin/adr" ]; then
+    sudo mkdir -p /usr/local/bin/adr
+    echo "Directory /usr/local/bin/adr created."
+else
+    echo "Directory /usr/local/bin/adr already exists."
+fi
+
+# Clone the adr-tools repository if not already cloned
+if [ ! -d "/usr/local/bin/adr/.git" ]; then
+    sudo git clone https://github.com/npryce/adr-tools.git /usr/local/bin/adr
+    echo "adr-tools repository cloned."
+else
+    echo "adr-tools repository already cloned."
+fi
+
+# Add adr-tools to the PATH if not already present
+# if ! echo "$PATH" | grep -q "/usr/local/bin/adr/src"; then
+#     export PATH="$PATH:/usr/local/bin/adr/src"
+#     # echo 'export PATH="$PATH:/usr/local/bin/adr/src"' >> ~/.bashrc
+#     echo "adr-tools path added to PATH."
+# else
+#     echo "adr-tools path already in PATH."
+# fi
+
+# Ensure adr script is executable
+if [ ! -x "/usr/local/bin/adr/src/adr" ]; then
+    sudo chmod +x /usr/local/bin/adr/src/adr
+    echo "adr script made executable."
+else
+    echo "adr script already executable."
+fi

--- a/engineering-base/devbox.json
+++ b/engineering-base/devbox.json
@@ -1,0 +1,13 @@
+{
+    "packages": [
+        "git",
+        "bash",
+        "coreutils"
+    ],
+    "shell": {
+        "init_hook": [
+            "./adr-setup.sh",
+            "export PATH=$PATH:/usr/local/bin/adr/src"
+        ]
+    }
+}

--- a/engineering-base/devbox.lock
+++ b/engineering-base/devbox.lock
@@ -1,0 +1,17 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "bash": {
+      "resolved": "github:NixOS/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c#bash",
+      "source": "nixpkg"
+    },
+    "coreutils": {
+      "resolved": "github:NixOS/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c#coreutils",
+      "source": "nixpkg"
+    },
+    "git": {
+      "resolved": "github:NixOS/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c#git",
+      "source": "nixpkg"
+    }
+  }
+}


### PR DESCRIPTION
* Provide an idempotent ADR set up script
* Initial Devbox configuration calling the script
* Devbox `init-hook` adds the ADR path to the shell `PATH`